### PR TITLE
fix checkbox modal template in stepway version

### DIFF
--- a/src/app/stepway/components/controls/CheckBox/editCheckBox/editCheckBox.component.js
+++ b/src/app/stepway/components/controls/CheckBox/editCheckBox/editCheckBox.component.js
@@ -17,31 +17,21 @@ export const editCheckBoxControlComponent = {
         <div class="row">
           <div class="col-md-12">
             <div class="form-group">
-              <label
-                for="inputDate"
-                class="control-label textControlLabel">
-                {{$ctrl.nyaSelect.temporyConfig.formlyLabel}}
-                <span
-                  ng-if="$ctrl.nyaSelect.temporyConfig.formlyRequired"
-                  class="textControlLabel">
-                  *
-                </span>
-              </label>
-              <div class="">
-                <div class="input-group" >
-                  <span class="input-group-addon">
-                    <i class="glyphicon glyphicon-calendar"></i>
-                  </span>
-                  <input
-                    type="text"
-                    class="form-control"
-                    uib-datepicker-popup="{{$ctrl.nyaSelect.temporyConfig.datepickerOptions.format}}"
-                    ng-model="$ctrl.demodt.dt"
-                    is-open="$ctrl.demodt.opened"
-                    datepicker-options="$ctrl.dateOptions"
-                    close-text="Close"
-                    ng-click="$ctrl.open({event : $event})"
-                  />
+              <div class="col-md-12">
+                <div class="checkbox">
+                  <label>
+                    <input
+                      type="checkbox"
+                      id="checkBox">
+                    <span class="blackText">
+                      {{$ctrl.nyaSelect.temporyConfig.formlyLabel}}
+                    </span>
+                    <span
+                      ng-if="$ctrl.nyaSelect.temporyConfig.formlyRequired"
+                      class="textControlLabel">
+                      *
+                    </span>
+                  </label>
                 </div>
                 <p class="help-block">
                   {{$ctrl.nyaSelect.temporyConfig.formlyDescription}}
@@ -66,45 +56,22 @@ export const editCheckBoxControlComponent = {
         <hr/>
         <div class="row">
           <div class="form-group">
-          <label class="col-lg-3 control-label greyText editPropertiesLabel">
-            {{'DATE_FORMAT' | translate}} :
-          </label>
-          <div class="col-lg-9">
-            <ol
-              class="nya-bs-select col-sm-12 col-xs-12 col-md-12 col-lg12"
-              ng-model="$ctrl.nyaSelect.temporyConfig.datepickerOptions.format"
-              id="dateformatSelect">
-              <li
-                class="nya-bs-option"
-                nya-bs-option="dateformat in $ctrl.demodt.formats"
-                value="dateformat">
-                <a>
-                  {{dateformat}}
-                </a>
-              </li>
-            </ol>
+            <label
+              for="inputTextLabelUpdate"
+              class="col-lg-3 control-label greyText editPropertiesLabel">
+              {{'LABEL_TEXT' | translate}} :
+            </label>
+            <div class="col-lg-9">
+              <input
+                type="text"
+                class="form-control"
+                ng-model="$ctrl.nyaSelect.temporyConfig.formlyLabel"
+                id="inputTextLabelUpdate"
+                placeholder="{{'ADD_EDIT_LABEL_HERE' | translate}}">
+            </div>
           </div>
         </div>
-      </div>
-      <div class="marginTopFivepixels"></div>
-      <div class="row">
-        <div class="form-group">
-          <label
-            for="inputTextLabelUpdate"
-            class="col-lg-3 control-label greyText editPropertiesLabel">
-            {{'LABEL_TEXT' | translate}} :
-          </label>
-          <div class="col-lg-9">
-            <input
-              type="text"
-              class="form-control"
-              ng-model="$ctrl.nyaSelect.temporyConfig.formlyLabel"
-              id="inputTextLabelUpdate"
-              placeholder="{{'ADD_EDIT_LABEL_HERE' | translate}}">
-          </div>
-        </div>
-      </div>
-      <div class="marginTopFivepixels"></div>
+        <div class="marginTopFivepixels"></div>
         <div class="row">
           <div class="form-group">
             <label
@@ -113,9 +80,7 @@ export const editCheckBoxControlComponent = {
               {{'REQUIRED' | translate}} :
             </label>
             <div class="col-lg-9">
-              <div class="checkboxCssCorrection">
-                &nbsp;
-              </div>
+              <div class="checkboxCssCorrection">&nbsp;</div>
               <input
                 type="checkbox"
                 ng-model="$ctrl.nyaSelect.temporyConfig.formlyRequired"


### PR DESCRIPTION
Reverts checkbox html template to the correct one before 9b8bc52 where it was switched to the datepicker's template